### PR TITLE
Add fallback to socket.SOCK_STREAM

### DIFF
--- a/pylcddc/iothread.py
+++ b/pylcddc/iothread.py
@@ -87,8 +87,12 @@ class IOThread(threading.Thread):
         # AF_UNIX for reliable datagram sockets, as opposed to AF_INET
         # SOCK_SEQPACKET guarantees reliability, but Windows will probably
         # never support it. At least Windows is starting to support AF_UNIX.
-        self._signalling_sockets = socket.socketpair(family=socket.AF_UNIX,
-                                                     type=socket.SOCK_SEQPACKET)
+        try:
+            self._signalling_sockets = socket.socketpair(
+                family=socket.AF_UNIX, type=socket.SOCK_SEQPACKET)
+        except OSError:
+            self._signalling_sockets = socket.socketpair(
+                family=socket.AF_UNIX, type=socket.SOCK_STREAM)
         self._signal_socket = self._signalling_sockets[0]
         self._client_signal_socket = self._signalling_sockets[1]
         self._signalling_selector.register(self._client_signal_socket,


### PR DESCRIPTION
SOCK_SEQPACKET is not available on macOS. This prevents following error:

    OSError: [Errno 43] Protocol not supported

Fixes: #2